### PR TITLE
automatically add gazebo models and worlds to gazebo_models_path

### DIFF
--- a/mrsl_models/package.xml
+++ b/mrsl_models/package.xml
@@ -40,14 +40,10 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+  <run_depend>gazebo_ros</run_depend>
 
-
-  <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- You can specify that this package is a metapackage here: -->
-    <!-- <metapackage/> -->
-
-    <!-- Other tools can request additional information be placed here -->
-
+    <gazebo_ros gazebo_model_path="${prefix}/models"/>
   </export>
+
 </package>

--- a/mrsl_quadrotor_description/package.xml
+++ b/mrsl_quadrotor_description/package.xml
@@ -41,13 +41,10 @@
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
+  <run_depend>gazebo_ros</run_depend>
 
-  <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- You can specify that this package is a metapackage here: -->
-    <!-- <metapackage/> -->
-
-    <!-- Other tools can request additional information be placed here -->
-
+    <gazebo_ros gazebo_model_path="${prefix}"/>
   </export>
+
 </package>


### PR DESCRIPTION
This automatically adds the models and worlds in mrsl_models and mrsl_quadrotor_description to the gazebo_model_path, alleviating any need to manually set gazebo environment variables. After building the packages, worlds can be launched using the typical rospack commands, e.g. $(find mrsl_quadrotor_description)/worlds/empty.world.